### PR TITLE
Add Dyalog v20's ⍛

### DIFF
--- a/autoload/langbar
+++ b/autoload/langbar
@@ -64,6 +64,7 @@
 ¨ each
 ⍨ switch
 ⍣ power
+⍛ behind
 . inner product
 ∘ outer product
 ⍤ rank

--- a/syntax/apl.vim
+++ b/syntax/apl.vim
@@ -7,7 +7,7 @@ sy region aplstr start=/"/ end=/"/
 sy region aplstr matchgroup=aplstr start=/'/rs=s+1 skip=/''/ end=/'/re=e-1 contains=aplquo oneline
 sy match aplquo /''/ contained
 sy match apladv /[\\\/⌿⍀¨⍨⌶&∥⌸]/
-sy match aplcnj /[.@∘⍠⍣⍤⍥⌺]/
+sy match aplcnj /[.@⍛∘⍠⍣⍤⍥⌺]/
 sy match aplvrb /[+\-×÷⌈⌊∣|⍳⍸?*⍟○!⌹<≤=>≥≠≡≢∊⍷∪∩~∨∧⍱⍲⍴,⍪⌽⊖⍉↑↓⊂⊃⊆⊇⌷⍋⍒⊤⊥⍕⍎⊣⊢⍁⍂≈⍯↗¤→]/
 sy match aplcns /[⍬⌾#]/
 sy match aplind /[[\];]/


### PR DESCRIPTION
Behind (⍛) will be in Dyalog v20. Add to this vim plugin ahead of time.